### PR TITLE
Temporary workaround to "Get unzip Progress" feature

### DIFF
--- a/MeltyInstaller/MainWindow.xaml.cs
+++ b/MeltyInstaller/MainWindow.xaml.cs
@@ -136,7 +136,7 @@ namespace MeltyInstaller
 
             client.Dispose();
 
-            PrintLog("Unzipping archives...");
+            PrintLog("Unzipping archives... (This might take a while and the installer might not be responsive during this time, please be patient!)");
 
             await Task.WhenAll(installInformation.Select(info => UnzipFile(info[1])));
 

--- a/MeltyInstaller/MainWindow.xaml.cs
+++ b/MeltyInstaller/MainWindow.xaml.cs
@@ -136,7 +136,7 @@ namespace MeltyInstaller
 
             client.Dispose();
 
-            PrintLog("Unzipping archives... (This might take a while and the installer might not be responsive during this time, please be patient!)");
+            PrintLog("Unzipping archives... (This might take a while and the installer might not be responsive during this process, please be patient!)");
 
             await Task.WhenAll(installInformation.Select(info => UnzipFile(info[1])));
 


### PR DESCRIPTION
I noticed when installing, windows would claim the installer to be "Not responsive" on my system after finishing the download part despite it clearly working properly in the end. I also noticed you guys intend to have a progress bar for this process in the future, but in the meanwhile I think a small warning would be useful for the user until you guys implement that feature to avoid confusion. I hope this message is in the right place and not overly verbose, I hope this commit is helpful, cheers!! Thank you